### PR TITLE
Added note about CPU frequency to fixes file

### DIFF
--- a/fixes.html
+++ b/fixes.html
@@ -166,6 +166,9 @@
                         <p>You should be able to get better resulty by improoving wifi quality and always upgrading to the newest Version.
                         You can download the new ESP32/8266 file with the newest duco release: <a href="https://github.com/revoxhere/duino-coin/releases">DuinoCoin Releases</a>
                     </p>
+                    <p>
+                        Make sure that the correct CPU Frequency is set when uploading the sketch, i.e. 160 MHz for an ESP8266.
+                    </p>
         
                     <br>
                     <center><p class="subtitle">Too many rejected Shares</p></center>


### PR DESCRIPTION
Added a note about CPU frequency to fixes file, as I found this troubleshooting guide very useful, but couldn't figure why my ESP8266 was mining too slow.

A mining speed of 4.5k H/S happens at 80 MHz, the correct mining speed of 9k H/S happens at 160 MHz.